### PR TITLE
remove useless type hints, make <,>,<=,>= actually return a boolean on the 1-arg arity, as per docstring

### DIFF
--- a/src/clojure/clojurewerkz/money/amounts.clj
+++ b/src/clojure/clojurewerkz/money/amounts.clj
@@ -151,10 +151,10 @@
   ([a b & more]
      (reduce min (min a b) more)))
 
-(defn ^boolean >
+(defn >
   "Returns true if the given money amounts are in monotonically decreasing order,
   otherwise false."
-  ([a] a)
+  ([a] true)
   ([^Money a ^Money b]
      (.isGreaterThan a b))
   ([a b & more]
@@ -164,10 +164,10 @@
          (> b (first more)))
        false)))
 
-(defn ^boolean >=
+(defn >=
   "Returns true if the given money amounts are in monotonically non-increasing order,
   otherwise false."
-  ([a] a)
+  ([a] true)
   ([^Money a ^Money b]
      (or (.isGreaterThan a b) (= a b)))
   ([a b & more]
@@ -177,10 +177,10 @@
          (>= b (first more)))
        false)))
 
-(defn ^boolean <
+(defn <
   "Returns true if the given money amounts are in monotonically decreasing order,
   otherwise false."
-  ([a] a)
+  ([a] true)
   ([^Money a ^Money b]
      (.isLessThan a b))
   ([a b & more]
@@ -190,10 +190,10 @@
          (< b (first more)))
        false)))
 
-(defn ^boolean <=
+(defn <=
   "Returns true if the given money amounts are in monotonically non-decreasing order,
   otherwise false."
-  ([a] a)
+  ([a] true)
   ([^Money a ^Money b]
      (or (.isLessThan a b) (= a b)))
   ([a b & more]


### PR DESCRIPTION
The boolean type-hint was useless since clojure only allows long/double primitive type hints, and was also in the wrong position for the same reason of https://github.com/clojurewerkz/scrypt/pull/1

The comparator functions returned the element in the 1-arity version while the docstring explicitely stated that they would return a boolean, fixed the function behaviour.
