### PR TITLE
Bugfix: clojurewerkz.money.amounts/convert-to now accepts BigDecimal multiplier.

### DIFF
--- a/src/clojure/clojurewerkz/money/amounts.clj
+++ b/src/clojure/clojurewerkz/money/amounts.clj
@@ -12,7 +12,7 @@
   (:refer-clojure :exclude [zero? max min > >= < <=])
   (:require [clojurewerkz.money.conversion :as cnv])
   (:import [org.joda.money Money BigMoney CurrencyUnit MoneyUtils]
-           [java.math RoundingMode BigDecimal]))
+           [java.math RoundingMode]))
 
 ;;
 ;; API
@@ -239,4 +239,4 @@
      java.math.RoundingMode constants with the same names
    * nil for no rounding"
   [^Money money ^CurrencyUnit currency multiplier rounding-mode]
-  (.convertedTo money currency (BigDecimal/valueOf multiplier) (cnv/to-rounding-mode rounding-mode)))
+  (.convertedTo money currency (bigdec multiplier) (cnv/to-rounding-mode rounding-mode)))

--- a/src/clojure/clojurewerkz/money/amounts.clj
+++ b/src/clojure/clojurewerkz/money/amounts.clj
@@ -107,7 +107,7 @@
    mode which is one of:
 
    * java.math.RoundingMode instances
-   * :floor, :ceiling, :up, :down, :half-up, :half-down, :hald-even that correspond to
+   * :floor, :ceiling, :up, :down, :half-up, :half-down, :half-even that correspond to
      java.math.RoundingMode constants with the same names
    * nil for no rounding"
   ([^Money money ^double multiplier]
@@ -120,7 +120,7 @@
    mode which is one of:
 
    * java.math.RoundingMode instances
-   * :floor, :ceiling, :up, :down, :half-up, :half-down, :hald-even that correspond to
+   * :floor, :ceiling, :up, :down, :half-up, :half-down, :half-even that correspond to
      java.math.RoundingMode constants with the same names
    * nil for no rounding"
   ([^Money money ^double multiplier]
@@ -220,7 +220,7 @@
    Rounding mode should be one of:
 
    * java.math.RoundingMode instances
-   * :floor, :ceiling, :up, :down, :half-up, :half-down, :hald-even that correspond to
+   * :floor, :ceiling, :up, :down, :half-up, :half-down, :half-even that correspond to
      java.math.RoundingMode constants with the same names
    * nil for no rounding"
   [^Money money ^long scale rounding-mode]
@@ -235,7 +235,7 @@
    Rounding mode should be one of:
 
    * java.math.RoundingMode instances
-   * :floor, :ceiling, :up, :down, :half-up, :half-down, :hald-even that correspond to
+   * :floor, :ceiling, :up, :down, :half-up, :half-down, :half-even that correspond to
      java.math.RoundingMode constants with the same names
    * nil for no rounding"
   [^Money money ^CurrencyUnit currency multiplier rounding-mode]

--- a/src/clojure/clojurewerkz/money/amounts.clj
+++ b/src/clojure/clojurewerkz/money/amounts.clj
@@ -230,7 +230,7 @@
   "Converts monetary amount in one currency to monetary amount in a different
    currency using the provided multiplier (exchange rate) and rounding mode.
 
-   Multipler should be either a java.math.BigDecimal or a double.
+   Multiplier should be either a java.math.BigDecimal or a double.
 
    Rounding mode should be one of:
 

--- a/test/clojurewerkz/money/amounts_test.clj
+++ b/test/clojurewerkz/money/amounts_test.clj
@@ -336,7 +336,13 @@
         (is (= ma (ams/amount-of cu/USD 45.30)))))))
 
 (deftest test-convert-to
-  (let [a    (ams/amount-of cu/USD 99.98)
-        b    (ams/amount-of cu/GBP 65.65)
-        rate 1.523]
-    (is (= a (ams/convert-to b cu/USD rate :down)))))
+  (testing "with Double rate"
+    (let [a    (ams/amount-of cu/USD 99.98)
+          b    (ams/amount-of cu/GBP 65.65)
+          rate 1.523]
+      (is (= a (ams/convert-to b cu/USD rate :down)))))
+  (testing "with BigDecimal rate"
+    (let [a    (ams/amount-of cu/USD 99.98)
+          b    (ams/amount-of cu/GBP 65.65)
+          rate 1.523M]
+      (is (= a (ams/convert-to b cu/USD rate :down))))))

--- a/test/clojurewerkz/money/amounts_test.clj
+++ b/test/clojurewerkz/money/amounts_test.clj
@@ -302,35 +302,35 @@
     (is (= ma (ams/amount-of cu/USD 50)))))
 
 (deftest test-round
-  (testing "with scale -1 and flooring rouding mode"
+  (testing "with scale -1 and flooring rounding mode"
     (let [oa (ams/amount-of cu/USD 40.01)
           ma (ams/round oa -1 :floor)]
       (is (= ma (ams/amount-of cu/USD 40))))
-    (testing "with scale -1 and up rouding mode"
+    (testing "with scale -1 and up rounding mode"
       (let [oa (ams/amount-of cu/USD 40.01)
             ma (ams/round oa -1 :up)]
         (is (= ma (ams/amount-of cu/USD 50)))))
-    (testing "with scale 0 and flooring rouding mode"
+    (testing "with scale 0 and flooring rounding mode"
       (let [oa (ams/amount-of cu/USD 45.24)
             ma (ams/round oa 0 :floor)]
         (is (= ma (ams/amount-of cu/USD 45)))))
-    (testing "with scale 0 and up rouding mode"
+    (testing "with scale 0 and up rounding mode"
       (let [oa (ams/amount-of cu/USD 45.24)
             ma (ams/round oa 0 :up)]
         (is (= ma (ams/amount-of cu/USD 46)))))
-    (testing "with scale 1 and flooring rouding mode"
+    (testing "with scale 1 and flooring rounding mode"
       (let [oa (ams/amount-of cu/USD 45.24)
             ma (ams/round oa 1 :floor)]
         (is (= ma (ams/amount-of cu/USD 45.20)))))
-    (testing "with scale 1 and up rouding mode"
+    (testing "with scale 1 and up rounding mode"
       (let [oa (ams/amount-of cu/USD 45.24)
             ma (ams/round oa 1 :up)]
         (is (= ma (ams/amount-of cu/USD 45.30)))))
-    (testing "with scale 2 and flooring rouding mode"
+    (testing "with scale 2 and flooring rounding mode"
       (let [oa (ams/amount-of cu/USD 45.24)
             ma (ams/round oa 2 :floor)]
         (is (= ma (ams/amount-of cu/USD 45.24)))))
-    (testing "with scale 2 and up rouding mode"
+    (testing "with scale 2 and up rounding mode"
       (let [oa (ams/amount-of cu/USD 45.24)
             ma (ams/round oa 1 :up)]
         (is (= ma (ams/amount-of cu/USD 45.30)))))))


### PR DESCRIPTION
The documentation says `Multiplier should be either a java.math.BigDecimal or a double.` But you'd get an `IllegalArgumentException` if you tried to pass in a BigDecimal.