### PR TITLE
Fix primitive type hints on vars

### DIFF
--- a/src/clojure/clojurewerkz/money/amounts.clj
+++ b/src/clojure/clojurewerkz/money/amounts.clj
@@ -63,12 +63,12 @@
   [^CurrencyUnit unit ^long amount]
   (Money/ofMinor unit amount))
 
-(defn ^long major-of
+(defn ^{:tag 'long} major-of
   "Returns the amount in major units as a long"
   [^Money money]
   (.getAmountMajorLong money))
 
-(defn ^long minor-of
+(defn ^{:tag 'long} minor-of
   "Returns the amount in minor units as a long"
   [^Money money]
   (.getAmountMinorLong money))


### PR DESCRIPTION
More information on this issue:
https://github.com/jonase/eastwood#wrong-tag

In short, the current code actually hints on the function `clojure.core/long` rather than the primitive type, which this PR fixes.

As an aside, I actually prefer return type hints just before the argument vector which avoids this issue with primitive types (and is also how it is [documented](http://clojure.org/java_interop#Java%20Interop-Type%20Hints)) but if you use Java class names, currently requires that the name is fully qualified even if it is imported in the ns. I believe this is slated to be fixed in a [future Clojure release](http://dev.clojure.org/jira/browse/CLJ-1232), after which, IMO the argument vector type hints will be superior.