### PR TITLE
Update JSON serializer to serialize to a locale-independent format

### DIFF
--- a/src/clojure/clojurewerkz/money/json.clj
+++ b/src/clojure/clojurewerkz/money/json.clj
@@ -40,14 +40,14 @@
    Currency units are serialized to strings by taking their ISO-4217 codes."
   (:require cheshire.generate
             [clojurewerkz.money.format :as fmt])
-  (:import [org.joda.money Money CurrencyUnit]))
-
+  (:import [org.joda.money Money CurrencyUnit]
+           [com.fasterxml.jackson.core.json WriterBasedJsonGenerator]))
 
 
 (cheshire.generate/add-encoder CurrencyUnit
-                               (fn [^CurrencyUnit cu ^com.fasterxml.jackson.core.json.WriterBasedJsonGenerator generator]
+                               (fn [^CurrencyUnit cu ^WriterBasedJsonGenerator generator]
                                  (.writeString generator (.getCode cu))))
 
 (cheshire.generate/add-encoder Money
-                               (fn [^Money m ^com.fasterxml.jackson.core.json.WriterBasedJsonGenerator generator]
+                               (fn [^Money m ^WriterBasedJsonGenerator generator]
                                  (.writeString generator (fmt/format m))))

--- a/src/clojure/clojurewerkz/money/json.clj
+++ b/src/clojure/clojurewerkz/money/json.clj
@@ -39,10 +39,17 @@
 
    Currency units are serialized to strings by taking their ISO-4217 codes."
   (:require cheshire.generate
+            [clojurewerkz.money.amounts :as ma]
             [clojurewerkz.money.format :as fmt])
   (:import [org.joda.money Money CurrencyUnit]
            [com.fasterxml.jackson.core.json WriterBasedJsonGenerator]))
 
+(defn- encode-money
+  "Encodes an instance of org.joda.money.Money as a string with an ISO-4217
+  currency code followed by a human-readable amount."
+  ^String
+  [^Money m]
+  (format "%s %s" (.getCode (ma/currency-of m)) (.getAmount m)))
 
 (cheshire.generate/add-encoder CurrencyUnit
                                (fn [^CurrencyUnit cu ^WriterBasedJsonGenerator generator]
@@ -50,4 +57,4 @@
 
 (cheshire.generate/add-encoder Money
                                (fn [^Money m ^WriterBasedJsonGenerator generator]
-                                 (.writeString generator (fmt/format m))))
+                                 (.writeString generator (encode-money m))))

--- a/test/clojurewerkz/money/json_test.clj
+++ b/test/clojurewerkz/money/json_test.clj
@@ -1,0 +1,15 @@
+(ns clojurewerkz.money.json-test
+  (:require [clojurewerkz.money.amounts :as ma]
+            [clojurewerkz.money.currencies :as cu]
+            clojurewerkz.money.json
+            [clojure.test :refer :all]
+            [cheshire.core :as json]))
+
+(deftest test-currency-encoder
+  (testing "Currency units are encoded in JSON as ISO-4217 codes."
+    (is (= "\"GBP\"" (json/generate-string (cu/for-code "GBP"))))))
+
+(deftest test-money-encoder
+  (testing "USD is encoded in JSON with an ISO-4217 code followed by the amount."
+    (is (= "\"USD 110.00\"" (json/generate-string (ma/parse "USD 110"))))
+    (is (= "\"JPY 100\"" (json/generate-string (ma/parse "JPY 100"))))))


### PR DESCRIPTION
As described in https://github.com/clojurewerkz/money/issues/9, the JSON serializer was formatting Money values in a locale-dependent format. This change updates the serialization format to one that can be read back in by `clojurewerkz.money.amounts/parse`.

Note that this will break backward compatibility, but based on discussion in #9 it seems that may not be a problem.

I did not see an opportunity here for encoding `Money` objects in a locale-dependent format - only one encoder can be added to cheshire for Money objects, and cheshire does not offer an opportunity for selecting between multiple encoders that I can see.