### PR TITLE
Add support for operations with BigDecimal and Money arguments

### DIFF
--- a/src/clojure/clojurewerkz/money/amounts.clj
+++ b/src/clojure/clojurewerkz/money/amounts.clj
@@ -113,10 +113,51 @@
   [^Iterable monies]
   (Money/total monies))
 
+(defprotocol AmountOps
+  (op-plus [other money rounding-mode])
+  (op-minus [other money rounding-mode])
+  (op-multiply [multiplier money rounding-mode])
+  (op-divide [multiplier money rounding-mode]))
+
+(extend-protocol AmountOps
+  Double
+  (op-plus [other ^Money money ^RoundingMode rounding-mode]
+    (.plus money other rounding-mode))
+  (op-minus [ other ^Money money ^RoundingMode rounding-mode]
+    (.minus money other rounding-mode))
+  (op-multiply [ multiplier ^Money money ^RoundingMode rounding-mode]
+    (.multipliedBy money multiplier rounding-mode))
+  (op-divide [multiplier ^Money money ^RoundingMode rounding-mode]
+    (.dividedBy money multiplier rounding-mode))
+  java.math.BigDecimal
+  (op-plus [other ^Money money ^RoundingMode rounding-mode]
+    (.plus money other rounding-mode))
+  (op-minus [ other ^Money money ^RoundingMode rounding-mode]
+    (.minus money other rounding-mode))
+  (op-multiply [ multiplier ^Money money ^RoundingMode rounding-mode]
+    (.multipliedBy money multiplier rounding-mode))
+  (op-divide [multiplier ^Money money ^RoundingMode rounding-mode]
+    (.dividedBy money multiplier rounding-mode))
+  Long
+  (op-multiply [ multiplier ^Money money ^RoundingMode rounding-mode]
+    (.multipliedBy money multiplier))
+  (op-divide [multiplier ^Money money ^RoundingMode rounding-mode]
+    (.dividedBy money multiplier rounding-mode))
+  Money
+  (op-plus [^Money other ^Money money ^RoundingMode rounding-mode]
+    (.plus money other))
+  (op-minus [^Money other ^Money money ^RoundingMode rounding-mode]
+    (.minus money other))
+  Iterable
+  (op-plus [other ^Money money ^RoundingMode rounding-mode]
+    (.plus money other))
+  (op-minus [other ^Money money ^RoundingMode rounding-mode]
+    (.minus money other)))
+
 (defn ^Money plus
   "Adds two monetary amounts together"
   [^Money money other]
-  (.plus money other))
+  (op-plus other money (cnv/to-rounding-mode nil)))
 
 (defn ^Money plus-major
   "Adds two monetary amounts together, taking one of them in
@@ -134,7 +175,7 @@
   "Subtracts one monetary amount from another, taking one of them in
    major units (e.g. dollars)"
   [^Money money other]
-  (.minus money other))
+  (op-minus other money (cnv/to-rounding-mode nil)))
 
 (defn ^Money minus-major
   "Subtracts one monetary amount from another, taking one of them in
@@ -156,9 +197,9 @@
      java.math.RoundingMode constants with the same names
    * nil for no rounding"
   ([^Money money ^double multiplier]
-     (.multipliedBy money multiplier (cnv/to-rounding-mode nil)))
+     (op-multiply multiplier money (cnv/to-rounding-mode nil)))
   ([^Money money ^double multiplier rounding-mode]
-     (.multipliedBy money multiplier (cnv/to-rounding-mode rounding-mode))))
+     (op-multiply multiplier money (cnv/to-rounding-mode rounding-mode))))
 
 (defn ^Money divide
   "Divides monetary amount by the given number. Takes an optional arounding
@@ -168,10 +209,10 @@
    * :floor, :ceiling, :up, :down, :half-up, :half-down, :half-even that correspond to
      java.math.RoundingMode constants with the same names
    * nil for no rounding"
-  ([^Money money ^double multiplier]
-     (.dividedBy money multiplier (cnv/to-rounding-mode nil)))
-  ([^Money money ^double multiplier rounding-mode]
-     (.dividedBy money multiplier (cnv/to-rounding-mode rounding-mode))))
+  ([^Money money multiplier]
+     (op-divide multiplier money (cnv/to-rounding-mode nil)))
+  ([^Money money multiplier rounding-mode]
+     (op-divide multiplier money (cnv/to-rounding-mode rounding-mode))))
 
 (defn ^Money parse
   "Parses a string in the format of [currency code] [amount as double]

--- a/test/clojurewerkz/money/amounts_test.clj
+++ b/test/clojurewerkz/money/amounts_test.clj
@@ -142,13 +142,23 @@
         b  10.00M
         c  (ams/of-minor  cu 1300)
         d  0.00M
+        e  (ams/amount-of cu 15.00)
+        f  10.00
+        g  (ams/amount-of cu 15.00)
+        h  (ams/amount-of cu 10.00)
         ^Money t1  (ams/plus a b)
-        ^Money t2  (ams/plus c d)]
+        ^Money t2  (ams/plus c d)
+        ^Money t3  (ams/plus e f)
+        ^Money t4  (ams/plus g h)]
 
     (is (= (.getCurrencyUnit t1) cu))
     (is (= (.getCurrencyUnit t2) cu))
+    (is (= (.getCurrencyUnit t3) cu))
+    (is (= (.getCurrencyUnit t4) cu))
     (is (= 25.00M (.getAmount t1)))
     (is (= 13.00M (.getAmount t2)))
+    (is (= 25.00M (.getAmount t3)))
+    (is (= 25.00M (.getAmount t4)))
     (is (= 38.00M (.getAmount (ams/plus t1 t2))) "add two Money values together")
     (is (= 39.00M (.getAmount (ams/plus t2 [t2 t2]))) "add a collection of Money values")))
 
@@ -184,12 +194,20 @@
         b  10.00M
         c  (ams/of-minor  cu 1300)
         d  0.00M
+        e  (ams/amount-of cu 15.00)
+        f  10.00
+        g  (ams/amount-of cu 15.00)
+        h  (ams/amount-of cu 10.00)
         ^Money t1  (ams/minus a b)
-        ^Money t2  (ams/minus c d)]
+        ^Money t2  (ams/minus c d)
+        ^Money t3  (ams/minus e f)
+        ^Money t4  (ams/minus g h)]
     (is (= (.getCurrencyUnit t1) cu))
     (is (= (.getCurrencyUnit t2) cu))
+    (is (= (.getCurrencyUnit t3) cu))
     (is (= 5.00M  (.getAmount t1)))
     (is (= 13.00M (.getAmount t2)))
+    (is (= 5.00M  (.getAmount t3)))
     (is (= 8.00M (.getAmount (ams/minus t2 t1))) "subtract one Money value from another")
     (is (= 3.00M (.getAmount (ams/minus t2 [t1 t1]))) "subtract multiple Money values from another")))
 
@@ -308,9 +326,19 @@
         ma (ams/multiply oa 10.1 :floor)]
     (is (= ma (ams/amount-of cu/USD 454.50)))))
 
+(deftest test-multiplication-bigdecimal-with-floor-rounding-mode
+  (let [oa (ams/amount-of cu/USD 45)
+        ma (ams/multiply oa 10.1M :floor)]
+    (is (= ma (ams/amount-of cu/USD 454.50)))))
+
 (deftest test-division
   (let [oa (ams/amount-of cu/USD 100)
         ma (ams/divide oa 2)]
+    (is (= ma (ams/amount-of cu/USD 50)))))
+
+(deftest test-division-bigdecimal-with-floor-rounding-mode
+  (let [oa (ams/amount-of cu/USD 100.01)
+        ma (ams/divide oa 2.0M :floor)]
     (is (= ma (ams/amount-of cu/USD 50)))))
 
 (deftest test-division-with-floor-rounding-mode


### PR DESCRIPTION
The joda money library has several overloaded methods for addition,
substraction, multiplication and division with double, BigDecimal,
long and Money arguments. The clojure wrapper only supported a subset.

Fixes #20 