### PR TITLE
Use bigint to return minor-of

### DIFF
--- a/src/clojure/clojurewerkz/money/amounts.clj
+++ b/src/clojure/clojurewerkz/money/amounts.clj
@@ -71,7 +71,7 @@
 (defn ^{:tag 'long} minor-of
   "Returns the amount in minor units as a long"
   [^Money money]
-  (.getAmountMinorLong money))
+  (bigint (.getAmountMinor money)))
 
 (defn ^CurrencyUnit currency-of
   "Returns the currency of a monetary amount"

--- a/src/clojure/clojurewerkz/money/amounts.clj
+++ b/src/clojure/clojurewerkz/money/amounts.clj
@@ -68,7 +68,7 @@
   [^Money money]
   (.getAmountMajorLong money))
 
-(defn ^{:tag 'long} minor-of
+(defn ^{:tag 'bigint} minor-of
   "Returns the amount in minor units as a long"
   [^Money money]
   (bigint (.getAmountMinor money)))

--- a/src/clojure/clojurewerkz/money/amounts.clj
+++ b/src/clojure/clojurewerkz/money/amounts.clj
@@ -69,7 +69,7 @@
   (.getAmountMajorLong money))
 
 (defn ^{:tag 'bigint} minor-of
-  "Returns the amount in minor units as a long"
+  "Returns the amount in minor units as a BigInt"
   [^Money money]
   (bigint (.getAmountMinor money)))
 

--- a/test/clojurewerkz/money/amounts_test.clj
+++ b/test/clojurewerkz/money/amounts_test.clj
@@ -54,6 +54,12 @@
        (cu/for-code "VND") 401  401
        CurrencyUnit/JPY    5000 5000))
 
+(deftest test-minor-units-of-exceed-long-limit
+  (let [cu CurrencyUnit/USD
+        amount Long/MAX_VALUE
+        ^Money money (ams/of-major cu amount)]
+    (is (= (ams/currency-of money) cu))
+    (is (= (* (bigint 100) amount) (ams/minor-of money)))))
 
 (deftest test-zero-amount
   (are [cu bdec] (let [^Money money (ams/zero cu)]


### PR DESCRIPTION
Found this through our generative testing.

It's an interesting scenario to get into, you can set the major to the max of Integer but then can't return the value.