### PR TITLE
Exclude abs in amounts.clj

### DIFF
--- a/src/clojure/clojurewerkz/money/amounts.clj
+++ b/src/clojure/clojurewerkz/money/amounts.clj
@@ -33,7 +33,7 @@
 
 (ns clojurewerkz.money.amounts
   "Operations on monetary amounts, including conversion, parsing, and predicates"
-  (:refer-clojure :exclude [zero? max min > >= < <=])
+  (:refer-clojure :exclude [zero? max min > >= < <= abs])
   (:require [clojurewerkz.money.conversion :as cnv])
   (:import [org.joda.money Money BigMoney CurrencyUnit MoneyUtils]
            [java.math RoundingMode]))


### PR DESCRIPTION
Clojure 1.11.0 introduced `abs` as a core function.

This PR just adds `abs` to the excluded symbols in `amounts.clj`