### PR TITLE
Remove minor-of type hint, fixes #34

### DIFF
--- a/src/clojure/clojurewerkz/money/amounts.clj
+++ b/src/clojure/clojurewerkz/money/amounts.clj
@@ -68,7 +68,7 @@
   [^Money money]
   (.getAmountMajorLong money))
 
-(defn ^{:tag 'bigint} minor-of
+(defn minor-of
   "Returns the amount in minor units as a BigInt"
   [^Money money]
   (bigint (.getAmountMinor money)))


### PR DESCRIPTION
This commit fixes the issue #34 by removing the `minor-of` return value type hint.

From clojure.org reference:

> In addition, the compiler will track the use of any return values and
> infer types for their use and so on, so very few hints are needed to get
> a fully compile-time resolved series of calls.

(Source: https://clojure.org/reference/java_interop#typehints)

The way I understand this is that return value type hints propagate. `minor-of` function calls `bigint`, which has `:tag clojure.lang.BigInt` metadata in it. My understanding is that compiler is able to understand that the return type of `minor-of` is `clojure.lang.BigInt` because `bigint` return value is already type hinted.